### PR TITLE
GraphQL fragmentの命名ルールが崩れてたので直した

### DIFF
--- a/web/containers/Session/ContentCard/ContentCardSpeaker.tsx
+++ b/web/containers/Session/ContentCard/ContentCardSpeaker.tsx
@@ -4,10 +4,10 @@ import { Text } from '../../../components';
 import { getTextStyle, borderRadius } from '../../../components/styles';
 
 import gql from 'graphql-tag';
-import { SpeakerFragment } from '../../../graphql/generated/SpeakerFragment';
+import { ContentCardSpeakerFragment } from '../../../graphql/generated/ContentCardSpeakerFragment';
 
-export const SPEAKER_FRAGMENT = gql`
-  fragment SpeakerFragment on Speaker {
+export const CONTENT_CARD_SPEAKER_FRAGMENT = gql`
+  fragment ContentCardSpeakerFragment on Speaker {
     id
     speakerId
     name
@@ -20,7 +20,7 @@ export const SPEAKER_FRAGMENT = gql`
 `;
 
 interface Props {
-  speaker: SpeakerFragment;
+  speaker: ContentCardSpeakerFragment;
   isJa: boolean;
 }
 

--- a/web/containers/Session/ContentCard/index.tsx
+++ b/web/containers/Session/ContentCard/index.tsx
@@ -3,7 +3,9 @@ import styled from 'styled-components';
 import moment from 'moment';
 import { Text, Tip } from '../../../components';
 import { colors, getTextStyle, borderRadius } from '../../../components/styles';
-import ContentCardSpeaker, { SPEAKER_FRAGMENT } from './ContentCardSpeaker';
+import ContentCardSpeaker, {
+  CONTENT_CARD_SPEAKER_FRAGMENT
+} from './ContentCardSpeaker';
 
 import gql from 'graphql-tag';
 import { ContentCardFragment } from '../../../graphql/generated/ContentCardFragment';
@@ -20,10 +22,10 @@ export const CONTENT_CARD_FRAGMENT = gql`
     outline
     outlineJa
     speakers {
-      ...SpeakerFragment
+      ...ContentCardSpeakerFragment
     }
   }
-  ${SPEAKER_FRAGMENT}
+  ${CONTENT_CARD_SPEAKER_FRAGMENT}
 `;
 
 interface Props {

--- a/web/containers/Top/ContentSection/ContentGrid/ContentGridItem.tsx
+++ b/web/containers/Top/ContentSection/ContentGrid/ContentGridItem.tsx
@@ -7,10 +7,10 @@ import { colors, borderRadius, boxShadow } from '../../../../components/styles';
 import { omitText, isJapan } from '../../../../utils';
 
 import gql from 'graphql-tag';
-import { ContentGridSessionFragment } from '../../../../graphql/generated/ContentGridSessionFragment';
+import { ContentGridItemFragment } from '../../../../graphql/generated/ContentGridItemFragment';
 
-export const CONTENT_GRID_SESSION_FRAGMENT = gql`
-  fragment ContentGridSessionFragment on Session {
+export const CONTENT_GRID_ITEM_FRAGMENT = gql`
+  fragment ContentGridItemFragment on Session {
     id
     sessionId
     title
@@ -35,7 +35,7 @@ export const CONTENT_GRID_SESSION_FRAGMENT = gql`
 
 interface Props {
   index: number;
-  session: ContentGridSessionFragment;
+  session: ContentGridItemFragment;
   onClick: (sessionId: number) => void;
 }
 

--- a/web/containers/Top/ContentSection/ContentGrid/index.tsx
+++ b/web/containers/Top/ContentSection/ContentGrid/index.tsx
@@ -1,8 +1,6 @@
 import * as React from 'react';
 import { MiniGrid } from '../../../../components';
-import ContentGridItem, {
-  CONTENT_GRID_SESSION_FRAGMENT
-} from './ContentGridItem';
+import ContentGridItem, { CONTENT_GRID_ITEM_FRAGMENT } from './ContentGridItem';
 
 import gql from 'graphql-tag';
 import { ContentGridFragment } from '../../../../graphql/generated/ContentGridFragment';
@@ -11,12 +9,12 @@ export const CONTENT_GRID_FRAGMENT = gql`
   fragment ContentGridFragment on Query {
     sessionList {
       nodes {
-        ...ContentGridSessionFragment
+        ...ContentGridItemFragment
       }
     }
   }
 
-  ${CONTENT_GRID_SESSION_FRAGMENT}
+  ${CONTENT_GRID_ITEM_FRAGMENT}
 `;
 
 interface Props {

--- a/web/graphql/generated/ContentCardSpeakerFragment.ts
+++ b/web/graphql/generated/ContentCardSpeakerFragment.ts
@@ -2,10 +2,10 @@
 // This file was automatically generated and should not be edited.
 
 // ====================================================
-// GraphQL fragment: SpeakerFragment
+// GraphQL fragment: ContentCardSpeakerFragment
 // ====================================================
 
-export interface SpeakerFragment {
+export interface ContentCardSpeakerFragment {
   __typename: "Speaker";
   id: string;
   speakerId: string;

--- a/web/graphql/generated/ContentGridItemFragment.ts
+++ b/web/graphql/generated/ContentGridItemFragment.ts
@@ -2,10 +2,10 @@
 // This file was automatically generated and should not be edited.
 
 // ====================================================
-// GraphQL fragment: ContentGridSessionFragment
+// GraphQL fragment: ContentGridItemFragment
 // ====================================================
 
-export interface ContentGridSessionFragment_speakers {
+export interface ContentGridItemFragment_speakers {
   __typename: "Speaker";
   id: string;
   speakerId: string;
@@ -15,7 +15,7 @@ export interface ContentGridSessionFragment_speakers {
   positionJa: string;
 }
 
-export interface ContentGridSessionFragment {
+export interface ContentGridItemFragment {
   __typename: "Session";
   id: string;
   sessionId: number;
@@ -28,5 +28,5 @@ export interface ContentGridSessionFragment {
   outline: string;
   outlineJa: string;
   tags: string[];
-  speakers: ContentGridSessionFragment_speakers[];
+  speakers: ContentGridItemFragment_speakers[];
 }


### PR DESCRIPTION
ReactのComponent名をGraphQLのfragmentのprefixにするというルールでやっていきたい…！
このFragment何？と思った時該当componentにｽｯと移動したい。