### PR TITLE
[WIP] service workerを `/` からではなく `/2018` から配信したい

### DIFF
--- a/web/next.config.js
+++ b/web/next.config.js
@@ -52,7 +52,7 @@ module.exports = withTypescript(withOffline({
         },
       }
     ],
-    importScripts: ['/sw.js'],
+    importScripts: ['sw.js'],
     clientsClaim: true,
     skipWaiting: true,
   },

--- a/web/pages/_app.tsx
+++ b/web/pages/_app.tsx
@@ -7,7 +7,7 @@ class MyApp extends App {
   public componentDidMount() {
     if ('serviceWorker' in navigator) {
       navigator.serviceWorker
-        .register('/service-worker.js', { scope: '/2018' })
+        .register('/2018/service-worker.js', { scope: '/2018/' })
         .then(() => {
           // console.log('service worker registration successful', registration);
           // TODO: push notification に対応するとか

--- a/web/server.js
+++ b/web/server.js
@@ -30,8 +30,8 @@ i18n
         const server = express()
 
         // service worker
-        server.get('/service-worker.js', (req, res) => app.serveStatic(req, res, path.join(__dirname, '.next', '/service-worker.js')))
-        server.get('/sw.js', (req, res) => app.serveStatic(req, res, path.join(__dirname, '.next', '/sw.js')))
+        server.get('/2018/service-worker.js', (req, res) => app.serveStatic(req, res, path.join(__dirname, '.next', 'service-worker.js')))
+        server.get('/2018/sw.js', (req, res) => app.serveStatic(req, res, path.join(__dirname, '.next', '/sw.js')))
 
         // web app manifest
         server.get('/2018/manifest.json', (req, res) => app.serveStatic(req, res, path.join(__dirname, '.next', 'manifest.json')))


### PR DESCRIPTION
- `/` から `/2018/` にリダイレクトするようにしてないと、 `/` アクセス時にSW周りにエラーが出る。Console見るでもしない限り影響なさそうだから無視でもいいかも？
- `swDst: '2018/service-worker.js` ってやらないと、多分Workboxが `/service-worker.js` にリクエスト出してエラー出てしまう。Console見るでもしない限り影響ないから無視でもいいかも