### PR TITLE
DataDogに渡すResourceNameを / 区切りとかにしてやるとうまいこと行くんじゃないのという話があったのでやってみる

### DIFF
--- a/server/gqlapi/gqlopencensus/middleware.go
+++ b/server/gqlapi/gqlopencensus/middleware.go
@@ -32,7 +32,7 @@ func ResolverMiddleware() graphql.FieldMiddleware {
 		defer span.End()
 
 		span.AddAttributes(
-			trace.StringAttribute(ext.ResourceName, datadogResourceName(ctx)),
+			trace.StringAttribute(ext.ResourceName, datadogResourceName(ctx)+"/"+rctx.Object+"/"+rctx.Field.Name),
 			trace.StringAttribute("resolver.object", rctx.Object),
 			trace.StringAttribute("resolver.field", rctx.Field.Name),
 			trace.StringAttribute("resolver.path", fmt.Sprintf("%+v", rctx.Path())),


### PR DESCRIPTION
![span resource](https://user-images.githubusercontent.com/125332/47141072-cbf09a00-d2fa-11e8-9149-347fa76b0970.png)
↑ResourceNameが一律だとTraceのListを見た時に全然わからなくて辛い