### PR TITLE
#222 やめる

### DIFF
--- a/server/gqlapi/gqlopencensus/middleware.go
+++ b/server/gqlapi/gqlopencensus/middleware.go
@@ -32,7 +32,7 @@ func ResolverMiddleware() graphql.FieldMiddleware {
 		defer span.End()
 
 		span.AddAttributes(
-			trace.StringAttribute(ext.ResourceName, datadogResourceName(ctx)+"/"+rctx.Object+"/"+rctx.Field.Name),
+			trace.StringAttribute(ext.ResourceName, datadogResourceName(ctx)),
 			trace.StringAttribute("resolver.object", rctx.Object),
 			trace.StringAttribute("resolver.field", rctx.Field.Name),
 			trace.StringAttribute("resolver.path", fmt.Sprintf("%+v", rctx.Path())),


### PR DESCRIPTION
#222 でResourceNameを細かく分けるのをやってみたけど微妙だったのでやめる。
https://docs.datadoghq.com/tracing/visualization/ を見る限り、クエリに対して1つのResourceNameを使うのがよさそう。

![default](https://user-images.githubusercontent.com/125332/47142712-7ddd9580-d2fe-11e8-9a76-549ea49eff4f.png)
